### PR TITLE
Add windows building instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # PikaEngine
 A light game engine meant to not impose a workflow on the user, but rather help him create the game in the way that is the most helpful to him
+
+# Building
+## Windows [ Visual Studio]
+- Open Pika directory
+- Right click and `Open with Visual Studio` or open it as a local folder from Visual Studio
+- Open CMakeLists.txt in the Solution Explorer
+- Press `Ctrl + S` to generate CMake
+- In VS top bar next to play button has a dropdown menu that says `Current Document(CMakeLists.txt)`. Chose `PikaCore.exe`
+- Press `Ctrl + F5` to build
+- Close Visual Studio
+- Delete `out` directory
+- Again open the directory with Visual Studio
+- Again open CMakeLists.txt and save with `Ctrl + S`
+
+# Adding module
+????


### PR DESCRIPTION
Since there is no building instructions I'm creating this proposal.
Discord server answers wasn't very helpful by comparing building to https://github.com/meemknight/LowLevelGameEngine
So I created steps based on what I could interpret from it.
These steps are NOT CORRECT, so I'm asking for someone that knows, please, give the actual steps to reproduce building process.
Visual studio is failing to build when `PicaCore.exe` is chosen.