### PR TITLE
Fix issues and allow FileMapping for Apple

### DIFF
--- a/Pika/thirdparty/safeSafe/include/safeSave/safeSave.h
+++ b/Pika/thirdparty/safeSafe/include/safeSave/safeSave.h
@@ -171,7 +171,7 @@ namespace sfs
 
 
 
-#if defined WIN32 || defined _WIN32 || defined __WIN32__ || defined __NT__
+#if defined WIN32 || defined _WIN32 || defined __WIN32__ || defined __NT__ || defined __APPLE__
 
 	struct FileMapping
 	{

--- a/Pika/thirdparty/sushi/include/sushi/sushiInput.h
+++ b/Pika/thirdparty/sushi/include/sushi/sushiInput.h
@@ -77,7 +77,7 @@ namespace sushi
 		float LT = 0.f;
 		float RT = 0.f;
 
-		struct
+		struct Joystick
 		{
 			constexpr static float JOYSTICK_SENSITIVITY = 0.7f;
 
@@ -88,7 +88,9 @@ namespace sushi
 			bool up() { return y > JOYSTICK_SENSITIVITY; }
 			bool down() { return y < -JOYSTICK_SENSITIVITY; }
 
-		}LStick, RStick;
+		};
+
+        Joystick LStick, RStick;
 
 		bool connected = 0;
 


### PR DESCRIPTION
Some compilers, like mine, are against having static data members in an anonymous struct and will throw an error if you do. Also, I considered testing this engine out on my MacOS, and I know Macs can support FileMapping.